### PR TITLE
Chore: Link to Tailwind Docs and not home page

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -47,7 +47,7 @@ export default function Header() {
         </Link>
       </div>
       <div className="text-base leading-5">
-        <a href="https://tailwindcss.com" className="font-medium text-gray-500 hover:text-gray-700">
+        <a href="https://tailwindcss.com/docs/installation" className="font-medium text-gray-500 hover:text-gray-700">
           Documentation &rarr;
         </a>
       </div>


### PR DESCRIPTION
Current state: `Documentation →` leads to Tailwind's HomePage `https://tailwindcss.com`

Changes: switched the link in `Documentation →` so we can link directly to the docs route and not the HomePage